### PR TITLE
fix: storing shipping address and require signing in before checkout

### DIFF
--- a/frontend/src/reducers/cartReducers.js
+++ b/frontend/src/reducers/cartReducers.js
@@ -6,7 +6,7 @@ import { CART_ADD_ITEM,
     } from '../constants/cartConstants'
 
 
-export const cartReducer = (state= {cartItems: [], shippigAddress: {} },action) => {
+export const cartReducer = (state= {cartItems: [], shippingAddress: {} },action) => {
     switch(action.type){
         case CART_ADD_ITEM:
             const item = action.payload

--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -15,6 +15,9 @@ function CartScreen() {
   const cart = useSelector(state => state.cart)
   const { cartItems } = cart
 
+  const userLogin = useSelector((state) => state.userLogin);
+  const { userInfo } = userLogin;
+
   useEffect(() =>{
     if(productId.id)
     {
@@ -33,7 +36,12 @@ function CartScreen() {
   };
 
   const checkoutHandler = () => {
-   navigate('/shipping')
+    if (!userInfo) {
+      window.confirm("Please sign in before placing an order.")
+      navigate('/sign-in')
+    } else {
+      navigate('/shipping')
+    }
   }
 
   return (


### PR DESCRIPTION
- fixed a typo that was preventing shipping address from being correctly stored/reloaded
- if user is not signed in and tries to check out, confirm box comes up that says "You must be signed in to place an order." After clicking OK, the user is redirected to the sign in page.
- if the user is already signed in, clicking checkout behaves as expected

resolves #114 : If a user's shipping information is already saved to their account, it will automatically be filled out.
resolves #112 : If user is not logged in, they will first be prompted to log-in before completing their purchase.
closes #111 : User Story: Checkout